### PR TITLE
Document accessors such as on-open

### DIFF
--- a/websocket.el
+++ b/websocket.el
@@ -320,7 +320,7 @@ EXTENSIONS can be NIL if none are in use.  An example value would
 be '(\"deflate-stream\" . (\"mux\" \"max-channels=4\")).
 
 Optionally you can specify
-ON_OPEN, ON-MESSAGE and ON-CLOSE callbacks as well.
+ON-OPEN, ON-MESSAGE and ON-CLOSE callbacks as well.
 
 The ON-OPEN callback is called after the connection is
 established with the websocket as the only argument.  The return


### PR DESCRIPTION
Docstring and argument information generated by defstruct is useless.  This change workaround this problem.  You can move document for websocket slots to each accessor functions, if you want to keep document for websocket-open short.
