### PR TITLE
Better wss error for emacs 23

### DIFF
--- a/websocket.el
+++ b/websocket.el
@@ -620,7 +620,12 @@ websocket processing, all of them having the error-condition
 `websocket-error' in addition to their own symbol:
 
 `websocket-unsupported-protocol': Data in the error signal is the
-protocol (such as \"wss\") that is unsupported.
+protocol that is unsupported.  For example, giving a URL starting
+with http by mistake raises this error.
+
+`websocket-wss-needs-emacs-24': Trying to connect wss protocol
+using Emacs < 24 raises this error.  You can catch this error
+also by `websocket-unsupported-protocol'.
 
 `websocket-received-error-http-response': Data in the error
 signal is the integer error number.


### PR DESCRIPTION
Hi, I've got a report from user saying that he can't connect to wss and it takes for a while to notice that he is using Emacs 23 and the problem was the one we already solved in #22 (Emacs 23 does not support TLS).  So, I guess it's better to have a finer message hence this PR.

My idea is to add a new error symbol `websocket-wss-needs-emacs-24` which is a "subtype" of the error `websocket-unsupported-protocol`.  This should not break backward compatibly for "good" elisp code (i.e., code which does not compare error symbol directly).
