### PR TITLE
Improve error display in default error handler

### DIFF
--- a/websocket-test.el
+++ b/websocket-test.el
@@ -573,3 +573,24 @@
     (should (eq 'conn-b (websocket-conn (car closed-websockets))))
     (should (eq 1 (length websocket-server-websockets)))
     (should (eq 'conn-a (websocket-conn (car websocket-server-websockets))))))
+
+(ert-deftest websocket-default-error-handler ()
+  (flet ((try-error
+          (callback-type err expected-message)
+          (flet ((display-warning
+                  (type message &optional level buffer-name)
+                  (should (eq type 'websocket))
+                  (should (eq level :error))
+                  (should (string= message expected-message))))
+            (websocket-default-error-handler nil
+                                             callback-type
+                                             err))))
+    (try-error
+     'on-message
+     '(end-of-buffer)
+     "in callback `on-message': End of buffer")
+
+    (try-error
+     'on-close
+     '(wrong-number-of-arguments 1 2)
+     "in callback `on-close': Wrong number of arguments: 1, 2")))

--- a/websocket.el
+++ b/websocket.el
@@ -363,9 +363,25 @@ the frame finishes.  If the frame is not completed, return NIL."
        :length (if payloadp payload-end 1)
        :completep (> fin 0)))))
 
+(defun websocket-format-error (err)
+  "Format an error message like command level does. ERR should be
+a cons of error symbol and error data."
+
+  ;; Formatting code adapted from `edebug-report-error'
+  (concat (or (get (car err) 'error-message)
+              (format "peculiar error (%s)" (car err)))
+          (when (cdr err)
+            (format ": %s"
+                    (mapconcat #'prin1-to-string
+                               (cdr err) ", ")))))
+
 (defun websocket-default-error-handler (websocket type err)
   "The default error handler used to handle errors in callbacks."
-  (message "Error found in callback `%S': %s" type (cdr err)))
+  (display-warning 'websocket
+                   (format "in callback `%S': %s"
+                           type
+                           (websocket-format-error err))
+                   :error))
 
 ;; Error symbols in use by the library
 (put 'websocket-unsupported-protocol 'error-conditions


### PR DESCRIPTION
- Pretty-print the error message, and include the error type.  Previously, only the error arguments were printed so that e.g. `end-of-buffer` would be rendered just as `nil`.  Pretty-printing makes the output of the default error handler consistent with default error output.
- Use `display-warning` rather than `message`.  Rationale: the error handler might be called many times in quick succession, overwriting previous messages. Also, the messages output by the error handler might be overwritten by messages emitted by other parts of the code (e.g. by websocket callbacks invoked after the error occurred.)
  
  Although past messages are always available in the `*Messages*` buffer, with `display-warning` errors are displayed more prominently since the `*Warnings*` buffer is unburied whenever new errors are printed.
