### PR TITLE
Permit non-numeric port number in websocket-server

### DIFF
--- a/websocket.el
+++ b/websocket.el
@@ -794,7 +794,7 @@ in the websocket client function `websocket-open'.  Returns the
 connection, which should be kept in order to pass to
 `websocket-server-close'."
   (let* ((conn (make-network-process
-                :name (format "websocket server on port %d" port)
+                :name (format "websocket server on port %s" port)
                 :server t
                 :family 'ipv4
                 :filter 'websocket-server-filter


### PR DESCRIPTION
This makes it possible to specify t for port, and let the system pick a
free listening port.
