### PR TITLE
Give the Origin header such that ipython's websocket accepts it

### DIFF
--- a/websocket.el
+++ b/websocket.el
@@ -852,32 +852,34 @@ connection, which should be kept in order to pass to
 (defun websocket-create-headers (url key protocol extensions)
   "Create connections headers for the given URL, KEY, PROTOCOL and EXTENSIONS.
 These are defined as in `websocket-open'."
-  (format (concat "Host: %s\r\n"
-                  "Upgrade: websocket\r\n"
-                  "Connection: Upgrade\r\n"
-                  "Sec-WebSocket-Key: %s\r\n"
-                  "Origin: %s\r\n"
-                  "Sec-WebSocket-Version: 13\r\n"
-                  (when protocol
-                    (concat
-                     (mapconcat (lambda (protocol)
-                                  (format "Sec-WebSocket-Protocol: %s" protocol))
-                                protocol "\r\n")
-                     "\r\n"))
-                  (when extensions
-                    (format "Sec-WebSocket-Extensions: %s\r\n"
-                            (mapconcat
-                             (lambda (ext)
-                               (concat (car ext)
-                                       (when (cdr ext) "; ")
-                                       (when (cdr ext)
-                                         (mapconcat 'identity (cdr ext) "; "))))
-                             extensions ", ")))
-                  "\r\n")
-          (url-host (url-generic-parse-url url))
-          key
-          system-name
-          protocol))
+  (let* ((parsed-url (url-generic-parse-url url))
+         (host-origin (format "%s:%s" (url-host parsed-url) (url-port parsed-url))))
+    (format (concat "Host: %s\r\n"
+                    "Upgrade: websocket\r\n"
+                    "Connection: Upgrade\r\n"
+                    "Sec-WebSocket-Key: %s\r\n"
+                    "Origin: %s\r\n"
+                    "Sec-WebSocket-Version: 13\r\n"
+                    (when protocol
+                      (concat
+                       (mapconcat (lambda (protocol)
+                                    (format "Sec-WebSocket-Protocol: %s" protocol))
+                                  protocol "\r\n")
+                       "\r\n"))
+                    (when extensions
+                      (format "Sec-WebSocket-Extensions: %s\r\n"
+                              (mapconcat
+                               (lambda (ext)
+                                 (concat (car ext)
+                                         (when (cdr ext) "; ")
+                                         (when (cdr ext)
+                                           (mapconcat 'identity (cdr ext) "; "))))
+                               extensions ", ")))
+                    "\r\n")
+            host-origin
+            key
+            url
+            protocol)))
 
 (defun websocket-get-server-response (websocket client-protocols client-extensions)
   "Get the websocket response from client WEBSOCKET."


### PR DESCRIPTION
I'm not sure if this is "the right thing", but `ein` does not work properly anymore and this fixes it.  The library that `ipython` uses for websockets (`tornado`) recently released 4.0 that seems to do stricter same-origin checking.  Anyone running `pip` will get the latest `tornado` and `ein` will break.

http://www.tornadoweb.org/en/stable/releases/v4.0.0.html

So what I did was go into tornado's source and print out the `host` and `origin` data it was checking to make sure were equal, and changed websocket.el so that they were in fact equal.

I know little about websockets, so I could be wrong, but seems to me this will not be a security issue because emacs doesn't run remote untrusted code the way a browser does?  So it shouldn't matter what websocket.el reports as the origin, since the origin should always be emacs and not some untrusted remote server.

I also don't know if this change will affect other libs that depend on websockets.
