### PR TITLE
Correctly parse fragmented HTTP header

### DIFF
--- a/websocket-test.el
+++ b/websocket-test.el
@@ -114,7 +114,9 @@
    (eq 400 (cdr (should-error (websocket-verify-response-code "HTTP/1.1 400")
                           :type 'websocket-received-error-http-response))))
   (should
-   (eq 200 (cdr (should-error (websocket-verify-response-code "HTTP/1.1 200"))))))
+   (eq 200 (cdr (should-error (websocket-verify-response-code "HTTP/1.1 200")))))
+  (should-error (websocket-verify-response-code "HTTP/1.")
+                :type 'websocket-invalid-header))
 
 (ert-deftest websocket-verify-headers ()
   (let ((accept "Sec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo=")
@@ -420,8 +422,9 @@
             (websocket frame)
             (lexical-let ((frame frame))
               (lambda () (push frame processed-frames))))
-           (websocket-verify-response-code (output) t)
-           (websocket-verify-headers (websocket output) t))
+           (websocket-verify-headers (websocket output) t)
+           (websocket-close (websocket)))
+      (websocket-outer-filter fake-ws "HTTP/1.1 101 Switching Protocols\r\n")
       (websocket-outer-filter fake-ws "Sec-")
       (should (eq (websocket-ready-state fake-ws) 'connecting))
       (should-not open-callback-called)

--- a/websocket.el
+++ b/websocket.el
@@ -451,8 +451,8 @@ ERR should be a cons of error symbol and error data."
 The only acceptable one to websocket is responce code 101.
 A t value will be returned on success, and an error thrown
 if not."
-  (string-match "HTTP/1.1 \\([[:digit:]]+\\)" output)
-  (unless (equal "101" (match-string 1 output))
+  (unless (and (string-match "HTTP/1.1 \\([[:digit:]]+\\)" output)
+               (equal "101" (match-string 1 output)))
        (signal 'websocket-received-error-http-response
                (string-to-number (match-string 1 output))))
   t)
@@ -747,19 +747,21 @@ connection is invalid, the connection will be closed."
     (setf (websocket-inflight-input websocket) nil)
     ;; If we've received the complete header, check to see if we've
     ;; received the desired handshake.
-    (when (and (eq 'connecting (websocket-ready-state websocket))
-               (setq header-end-pos (string-match "\r\n\r\n" text))
+    (when (and (eq 'connecting (websocket-ready-state websocket)))
+      (if (and (setq header-end-pos (string-match "\r\n\r\n" text))
                (setq start-point (+ 4 header-end-pos)))
-      (condition-case err
-          (progn
-            (websocket-verify-response-code text)
-            (websocket-verify-headers websocket text)
-            (websocket-process-headers (websocket-url websocket) text))
-        (error
-         (websocket-close websocket)
-         (signal (car err) (cdr err))))
-      (setf (websocket-ready-state websocket) 'open)
-      (websocket-try-callback 'websocket-on-open 'on-open websocket))
+	(progn
+	  (condition-case err
+	      (progn
+		(websocket-verify-response-code text)
+		(websocket-verify-headers websocket text)
+		(websocket-process-headers (websocket-url websocket) text))
+	    (error
+	     (websocket-close websocket)
+	     (signal (car err) (cdr err))))
+	  (setf (websocket-ready-state websocket) 'open)
+	  (websocket-try-callback 'websocket-on-open 'on-open websocket))
+	(setf (websocket-inflight-input websocket) text)))
     (when (eq 'open (websocket-ready-state websocket))
       (websocket-process-input-on-open-ws
        websocket (substring text (or start-point 0))))))


### PR DESCRIPTION
Partial HTTP response header was not remembered and subsequently concatenated with data received later.