### PR TITLE
Function test improvements for Windows: SIGSTP

### DIFF
--- a/websocket-functional-test.el
+++ b/websocket-functional-test.el
@@ -79,7 +79,10 @@
 (websocket-close wstest-ws)
 (assert (null (websocket-openp wstest-ws)))
 
-(stop-process wstest-server-proc)
+(if (not (eq system-type 'windows-nt))
+    ; Windows doesn't have support for the SIGSTP signal, so we'll just kill
+    ; the process.
+    (stop-process wstest-server-proc))
 (kill-process wstest-server-proc)
 
 ;; Make sure the processes are closed.  This happens asynchronously,


### PR DESCRIPTION
Windows doesn't support the SIGSTP signal, so we just kill the Tornado process if we detect we're running on Windows.

This fixes one of the issues in #42, "Functional tests do not pass on Windows".