### PR TITLE
Allow websocket-server's listen host to be set

### DIFF
--- a/testserver.py
+++ b/testserver.py
@@ -29,6 +29,6 @@ if __name__ == "__main__":
         (r"/", EchoWebSocket),
     ])
     server = httpserver.HTTPServer(application)
-    server.listen(9999)
+    server.listen(9999, "127.0.0.1")
     logging.info("STARTED: Server start listening")
     ioloop.IOLoop.instance().start()

--- a/websocket-functional-test.el
+++ b/websocket-functional-test.el
@@ -123,6 +123,7 @@
 (setq wstest-closed nil)
 (setq server-conn (websocket-server
                    9998
+                   :host 'local
                    :on-message (lambda (ws frame)
                                  (message "Server received text!")
                                  (websocket-send-text ws

--- a/websocket.el
+++ b/websocket.el
@@ -820,6 +820,11 @@ of populating the list of server extensions to WEBSOCKET."
 
 (defun* websocket-server (port &rest plist)
   "Open a websocket server on PORT.
+If the plist contains a `:host' HOST pair, this value will be
+used to configure the addresses the socket listens on. The symbol
+`local' specifies the local host. If unspecified or nil, the
+socket will listen on all addresses.
+
 This also takes a plist of callbacks: `:on-open', `:on-message',
 `:on-close' and `:on-error', which operate exactly as documented
 in the websocket client function `websocket-open'.  Returns the
@@ -833,6 +838,7 @@ connection, which should be kept in order to pass to
                 :log 'websocket-server-accept
                 :filter-multibyte nil
                 :plist plist
+                :host (plist-get plist :host)
                 :service port)))
     conn))
 


### PR DESCRIPTION
This is useful when you only want to listen on localhost, potentially avoiding things like firewall prompts.

I was unable to get all the unit tests to pass, as I only have a 32-bit version of Emacs. See issue #41. 
I was unable to get all the functional tests to pass. See issue #42 for a list of the problems that I ran into.

Is this change small enough that you can help me test it?