### PR TITLE
Prevent emacs from asking users about killing server process on exit

### DIFF
--- a/websocket.el
+++ b/websocket.el
@@ -848,6 +848,7 @@ connection, which should be kept in order to pass to
                 :name (format "websocket server on port %s" port)
                 :server t
                 :family 'ipv4
+                :noquery t
                 :filter 'websocket-server-filter
                 :log 'websocket-server-accept
                 :filter-multibyte nil


### PR DESCRIPTION
Hi @ahyatt,

This change prevents emacs from querying users about killing network process on exit when websocket server is running. I think it's better because users don't need the query.