### PR TITLE
make nowait optional

### DIFF
--- a/websocket-functional-test.el
+++ b/websocket-functional-test.el
@@ -116,6 +116,7 @@
         wstest-msgs nil)
   (sleep-for 0.3)
   (assert (websocket-openp wstest-ws))
+  (sleep-for 0.6)
   (assert (eq 'open (websocket-ready-state wstest-ws)))
   (assert (null wstest-msgs))
   (websocket-send-text wstest-ws "Hi!")

--- a/websocket.el
+++ b/websocket.el
@@ -718,10 +718,6 @@ Default nil.
                      (websocket-calculate-accept key))))
     (unless conn (error "Could not establish the websocket connection to %s" url))
     (process-put conn :websocket websocket)
-    (when nowait
-      (process-put conn :key key)
-      (process-put conn :protocols protocols)
-      (process-put conn :extensions extensions))
     (set-process-filter conn
                         (lambda (process output)
                           (let ((websocket (process-get process :websocket)))
@@ -731,25 +727,11 @@ Default nil.
      (lambda (process change)
        (let ((websocket (process-get process :websocket)))
          (websocket-debug websocket "State change to %s" change)
-         (when (eq 'open (process-status process))
-           (websocket-handshake websocket
-                                (process-get process :key)
-                                (process-get process :protocols)
-                                (process-get process :extensions)))
          (when (and
                 (member (process-status process) '(closed failed exit signal))
                 (not (eq 'closed (websocket-ready-state websocket))))
            (websocket-try-callback 'websocket-on-close 'on-close websocket)))))
     (set-process-query-on-exit-flag conn nil)
-    (unless nowait
-      (websocket-handshake websocket key protocols extensions))
-    (websocket-debug websocket "Websocket opened")
-    websocket))
-
-(defun websocket-handshake (websocket key protocols extensions)
-  (let* ((url (websocket-url websocket))
-         (url-struct (url-generic-parse-url url))
-         (conn (websocket-conn websocket)))
     (process-send-string conn
                          (format "GET %s HTTP/1.1\r\n"
                                  (let ((path (url-filename url-struct)))
@@ -757,7 +739,9 @@ Default nil.
     (websocket-debug websocket "Sending handshake, key: %s, acceptance: %s"
                      key (websocket-accept-string websocket))
     (process-send-string conn
-                         (websocket-create-headers url key protocols extensions))))
+                         (websocket-create-headers url key protocols extensions))
+    (websocket-debug websocket "Websocket opened")
+    websocket))
 
 (defun websocket-process-headers (url headers)
   "On opening URL, process the HEADERS sent from the server."

--- a/websocket.el
+++ b/websocket.el
@@ -609,7 +609,8 @@ connecting or open."
 
 (defun* websocket-open (url &key protocols extensions (on-open 'identity)
                             (on-message (lambda (_w _f))) (on-close 'identity)
-                            (on-error 'websocket-default-error-handler))
+                            (on-error 'websocket-default-error-handler)
+                            (nowait nil))
   "Open a websocket connection to URL, returning the `websocket' struct.
 The PROTOCOL argument is optional, and setting it will declare to
 the server that this client supports the protocols in the list
@@ -694,9 +695,9 @@ describing the problem with the frame.
                           (host (url-host url-struct)))
                        (if (eq type 'plain)
                            (make-network-process :name name :buffer nil :host host
-                                                 :service port :nowait nil)
+                                                 :service port :nowait nowait)
                          (condition-case-unless-debug nil
-                             (open-network-stream name nil host port :type type :nowait nil)
+                             (open-network-stream name nil host port :type type :nowait nowait)
                            (wrong-number-of-arguments
                             (signal 'websocket-wss-needs-emacs-24 "wss")))))
                  (signal 'websocket-unsupported-protocol (url-type url-struct))))

--- a/websocket.el
+++ b/websocket.el
@@ -680,6 +680,10 @@ describing the invalid header received from the server.
 
 `websocket-unparseable-frame': Data in the error is a string
 describing the problem with the frame.
+
+`nowait': If NOWAIT is non-nil,
+return without waiting for the connection to complete.
+Default nil.
 "
   (let* ((name (format "websocket to %s" url))
          (url-struct (url-generic-parse-url url))


### PR DESCRIPTION
Hi! I'm using this library in [yuya373/emacs-slack: slack client for emacs](https://github.com/yuya373/emacs-slack) and works almost perfectly.
But when I lost network connection and get another network connection (eg. home wifi → train → office wifi) and trying reconnect by `websocket-open`, `websocket-open` hangs at [this line](https://github.com/ahyatt/emacs-websocket/blob/master/websocket.el#L699).

I set `:nowait t`, it does not hangs and successfully connected.
Is there any drawback to set `:nowait t`?

