### PR TITLE
ensure handshake is performed

### DIFF
--- a/websocket.el
+++ b/websocket.el
@@ -730,7 +730,7 @@ to the websocket protocol.
      conn
      (websocket-sentinel url conn key protocols extensions custom-header-alist nowait))
     (set-process-query-on-exit-flag conn nil)
-    (unless nowait
+    (when (eq 'open (process-status conn))
       (websocket-handshake url conn key protocols extensions custom-header-alist))
     websocket))
 

--- a/websocket.el
+++ b/websocket.el
@@ -730,7 +730,7 @@ to the websocket protocol.
      conn
      (websocket-sentinel url conn key protocols extensions custom-header-alist nowait))
     (set-process-query-on-exit-flag conn nil)
-    (websocket-handshake url conn key protocols extensions custom-header-alist)
+    (websocket-ensure-handshake url conn key protocols extensions custom-header-alist)
     websocket))
 
 (defun websocket-sentinel (url conn key protocols extensions custom-header-alist nowait)
@@ -739,13 +739,13 @@ to the websocket protocol.
         (websocket-debug websocket "State change to %s" change)
         (let ((status (process-status process)))
           (when (and nowait (eq status 'open))
-            (websocket-handshake url conn key protocols extensions custom-header-alist))
+            (websocket-ensure-handshake url conn key protocols extensions custom-header-alist))
 
           (when (and (member status '(closed failed exit signal))
                      (not (eq 'closed (websocket-ready-state websocket))))
             (websocket-try-callback 'websocket-on-close 'on-close websocket))))))
 
-(defun websocket-handshake (url conn key protocols extensions custom-header-alist)
+(defun websocket-ensure-handshake (url conn key protocols extensions custom-header-alist)
   (let ((url-struct (url-generic-parse-url url))
         (websocket (process-get conn :websocket)))
     (when (and (eq 'connecting (websocket-ready-state websocket))

--- a/websocket.el
+++ b/websocket.el
@@ -730,8 +730,7 @@ to the websocket protocol.
      conn
      (websocket-sentinel url conn key protocols extensions custom-header-alist nowait))
     (set-process-query-on-exit-flag conn nil)
-    (when (eq 'open (process-status conn))
-      (websocket-handshake url conn key protocols extensions custom-header-alist))
+    (websocket-handshake url conn key protocols extensions custom-header-alist)
     websocket))
 
 (defun websocket-sentinel (url conn key protocols extensions custom-header-alist nowait)
@@ -749,16 +748,17 @@ to the websocket protocol.
 (defun websocket-handshake (url conn key protocols extensions custom-header-alist)
   (let ((url-struct (url-generic-parse-url url))
         (websocket (process-get conn :websocket)))
-    (process-send-string conn
-                         (format "GET %s HTTP/1.1\r\n"
-                                 (let ((path (url-filename url-struct)))
-                                   (if (> (length path) 0) path "/"))))
-    (websocket-debug websocket "Sending handshake, key: %s, acceptance: %s"
-                     key (websocket-accept-string websocket))
-    (process-send-string conn
-                         (websocket-create-headers
-                          url key protocols extensions custom-header-alist))
-    (websocket-debug websocket "Websocket opened")))
+    (when (and (eq 'connecting (websocket-ready-state websocket))
+               (eq 'open (process-status conn)))
+      (process-send-string conn
+                           (format "GET %s HTTP/1.1\r\n"
+                                   (let ((path (url-filename url-struct)))
+                                     (if (> (length path) 0) path "/"))))
+      (websocket-debug websocket "Sending handshake, key: %s, acceptance: %s"
+                       key (websocket-accept-string websocket))
+      (process-send-string conn
+                           (websocket-create-headers
+                            url key protocols extensions custom-header-alist)))))
 
 (defun websocket-process-headers (url headers)
   "On opening URL, process the HEADERS sent from the server."


### PR DESCRIPTION
emacs26 pass :nowait to `open-gnutls-stream` but emacs25 doesn't.
emacs-26 branch on github:
https://github.com/emacs-mirror/emacs/blob/emacs-26/lisp/net/network-stream.el#L381
emacs-25 branch on github:
https://github.com/emacs-mirror/emacs/blob/emacs-25/lisp/net/network-stream.el#L354

And other open stream functions which is used when gnutls is not available
seems don't support :nowait arguments, so we should check
process-status is open or not instead of passed argument `nowait`.