### PR TITLE
Fix handshake when nowait

### DIFF
--- a/websocket.el
+++ b/websocket.el
@@ -740,10 +740,9 @@ to the websocket protocol.
 (defun websocket-ensure-handshake (url conn key protocols extensions custom-header-alist nowait)
   (let ((url-struct (url-generic-parse-url url))
         (websocket (process-get conn :websocket)))
-    (when(and (eq 'connecting (websocket-ready-state websocket))
-              (memq (process-status conn)
-                    (or (and nowait '(connect run))
-                        '(open run))))
+    (when (and (eq 'connecting (websocket-ready-state websocket))
+               (memq (process-status conn)
+                     (list 'run (if nowait 'connect 'open))))
       (process-send-string conn
                            (format "GET %s HTTP/1.1\r\n"
                                    (let ((path (url-filename url-struct)))

--- a/websocket.el
+++ b/websocket.el
@@ -722,7 +722,7 @@ to the websocket protocol.
      conn
      (websocket-sentinel url conn key protocols extensions custom-header-alist nowait))
     (set-process-query-on-exit-flag conn nil)
-    (websocket-ensure-handshake url conn key protocols extensions custom-header-alist)
+    (websocket-ensure-handshake url conn key protocols extensions custom-header-alist nowait)
     websocket))
 
 (defun websocket-sentinel (url conn key protocols extensions custom-header-alist nowait)
@@ -731,17 +731,19 @@ to the websocket protocol.
         (websocket-debug websocket "State change to %s" change)
         (let ((status (process-status process)))
           (when (and nowait (eq status 'open))
-            (websocket-ensure-handshake url conn key protocols extensions custom-header-alist))
+            (websocket-ensure-handshake url conn key protocols extensions custom-header-alist nowait))
 
           (when (and (member status '(closed failed exit signal))
                      (not (eq 'closed (websocket-ready-state websocket))))
             (websocket-try-callback 'websocket-on-close 'on-close websocket))))))
 
-(defun websocket-ensure-handshake (url conn key protocols extensions custom-header-alist)
+(defun websocket-ensure-handshake (url conn key protocols extensions custom-header-alist nowait)
   (let ((url-struct (url-generic-parse-url url))
         (websocket (process-get conn :websocket)))
-    (when (and (eq 'connecting (websocket-ready-state websocket))
-               (eq 'open (process-status conn)))
+    (when(and (eq 'connecting (websocket-ready-state websocket))
+              (eq (process-status conn)
+                  (or (and nowait 'connect)
+                      'open)))
       (process-send-string conn
                            (format "GET %s HTTP/1.1\r\n"
                                    (let ((path (url-filename url-struct)))

--- a/websocket.el
+++ b/websocket.el
@@ -741,9 +741,9 @@ to the websocket protocol.
   (let ((url-struct (url-generic-parse-url url))
         (websocket (process-get conn :websocket)))
     (when(and (eq 'connecting (websocket-ready-state websocket))
-              (eq (process-status conn)
-                  (or (and nowait 'connect)
-                      'open)))
+              (memq (process-status conn)
+                    (or (and nowait '(connect run))
+                        '(open run))))
       (process-send-string conn
                            (format "GET %s HTTP/1.1\r\n"
                                    (let ((path (url-filename url-struct)))


### PR DESCRIPTION
In the case of `:nowait t`, some servers (such as Slack servers) may return a 408 (request timeout) status.
This can be fixed by doing a handshake when returning `'connect`, since `process-status` returns `'connect` before returning `'open` when `:nowait t`.
And if some options are not available (eg, `gnutls-available-p` returns nil),` process-status` returns `'run` instead of `'open` (Even if I set to `nowait` to `t`), so We should perform a handshake when `process-status` returns `'run`.