### PR TITLE
[WIP] Enable option of localhost test server

### DIFF
--- a/testserver.py
+++ b/testserver.py
@@ -1,0 +1,34 @@
+import logging
+import tornado
+import tornado.web
+from tornado import httpserver
+from tornado import ioloop
+from tornado import websocket
+
+
+class EchoWebSocket(websocket.WebSocketHandler):
+
+    def open(self):
+        logging.info("OPEN")
+
+    def on_message(self, message):
+        logging.info(u"ON_MESSAGE: {0}".format(message))
+        self.write_message(u"You said: {0}".format(message))
+
+    def on_close(self):
+        logging.info("ON_CLOSE")
+
+    def allow_draft76(self):
+        return False
+
+
+if __name__ == "__main__":
+    import tornado.options
+    tornado.options.parse_command_line()
+    application = tornado.web.Application([
+        (r"/", EchoWebSocket),
+    ])
+    server = httpserver.HTTPServer(application)
+    server.listen(9999, "127.0.0.1")
+    logging.info("STARTED: Server start listening")
+    ioloop.IOLoop.instance().start()

--- a/testserver.py
+++ b/testserver.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import logging
 import tornado
 import tornado.web
@@ -12,8 +13,8 @@ class EchoWebSocket(websocket.WebSocketHandler):
         logging.info("OPEN")
 
     def on_message(self, message):
-        logging.info(u"ON_MESSAGE: {0}".format(message))
-        self.write_message(u"You said: {0}".format(message))
+        logging.info("ON_MESSAGE: {0}".format(message))
+        self.write_message("You said: {0}".format(message))
 
     def on_close(self):
         logging.info("ON_CLOSE")

--- a/websocket-functional-test.el
+++ b/websocket-functional-test.el
@@ -37,6 +37,9 @@
 
 (setq websocket-debug t)
 
+(unless wstest-server-url
+  (setq wstest-server-url "wss://echo.websocket.org"))
+
 (defvar wstest-server-buffer (get-buffer-create "*wstest-server*"))
 (defvar wstest-server-name "wstest-server")
 (defvar wstest-server-proc
@@ -71,7 +74,7 @@ written to be used widely."
              (wstest-msg)
              (wstest-ws
               (websocket-open
-               "wss://echo.websocket.org"
+               wstest-server-url
                :on-message (lambda (_websocket frame)
                              (setq wstest-msg (websocket-frame-text frame)))
                :on-close (lambda (_websocket) (setq wstest-closed t)))))

--- a/websocket-functional-test.el
+++ b/websocket-functional-test.el
@@ -37,14 +37,15 @@
 
 (setq websocket-debug t)
 
-(unless wstest-server-url
+(unless (boundp 'wstest-server-url)
   (setq wstest-server-url "wss://echo.websocket.org"))
 
 (defvar wstest-server-buffer (get-buffer-create "*wstest-server*"))
 (defvar wstest-server-name "wstest-server")
-(defvar wstest-server-proc
-  (start-process wstest-server-name wstest-server-buffer
-                 "python" "testserver.py" "--log_to_stderr" "--logging=debug"))
+(when wstest-server-url "wss://127.0.0.1:9999"
+  (setq wstest-server-proc
+    (start-process wstest-server-name wstest-server-buffer
+                   "python3" "testserver.py" "--log_to_stderr" "--logging=debug")))
 (sleep-for 1)
 
 (defvar wstest-msgs nil)
@@ -83,7 +84,10 @@ written to be used widely."
         (should (null wstest-msg))
         (websocket-send-text wstest-ws "Hi!")
         (should (websocket-test-wait-with-timeout 5 (equal wstest-msg "Hi!")))
-        (websocket-close wstest-ws))))
+        (websocket-close wstest-ws)
+        (when wstest-server-proc
+          (sleep-for 1)
+          (kill-process wstest-server-proc)))))
 
 (ert-deftest websocket-server ()
   (let* ((wstest-closed)


### PR DESCRIPTION
Continuing from #64 

What I had in mind was something like this PR.  Unfortunately it doesn't yet work correctly, and seems to have exposed an unhandled failure case:
```
   passed  27/32  websocket-server-close
Invalid client headers found in: 


   passed  28/32  websocket-server-filter
   passed  29/32  websocket-to-bytes
Websocket client connection: Host header not found
Websocket client connection: Upgrade: websocket not found
Websocket client connect: No key sent
Websocket client connect: No key sent
Websocket client connection: HTTP/1.1 not found
   passed  30/32  websocket-verify-client-headers
```

Anyways, I thought I'd take a quick stab at the problem today, and this is what I came up with.  Sorry if there are any dumb errors, I will confess it's rushed work.