### PR TITLE
Cleanups of obsolete functions, stylistic improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.elc
+
+# ELPA-generated files.
+/websocket-autoloads.el
+/websocket-pkg.el


### PR DESCRIPTION
    * .gitignore: New file.

    * websocket.el: Prefer #' to quote function names. (websocket--if-when-compile): New macro. (websocket-get-bytes, websocket-to-bytes, websocket-get-payload-len): Use `bindat-type` when available. (websocket-encode-frame): Add FIXME. (websocket-process-headers): Fix(?) regexp.

    * websocket-test.el: Don't use obsolete `cl` and deprecated `s`. Fix a few warnings about improper use of single-quotes in docstrings. Prefer #' to quote function names.  Fix warnings about unused variables. (websocket-outer-filter): Don't use `lexical-let` since we use `lexical-binding` already. (websocket-default-error-handler): Fix misuse of `cl-letf/flet`.

    * websocket-functional-test.el: Use `nsm` to control trust. Don't use obsolete `cl` and deprecated `f`. Fix warnings about unused variables.  Require `ert` for the `should` used outside of `ert-deftest`. (websocket-functional-client-test): Use `nsm-trust-local-network` instead of the old `tls-checktrust`. (websocket-ft-testserver): Use `macroexp-file-name`.